### PR TITLE
Use internal Gem cache for CI

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -74,4 +74,9 @@ export GEM_HOME=/cache
 export BUNDLE_APP_CONFIG=/cache
 export RAILS_ENV=test RACK_ENV=test
 
+cat > "$BUNDLE_APP_CONFIG/config" <<EOF
+BUNDLE_MIRROR__HTTPS://RUBYGEMS__ORG/: https://gems.stembolt.io/
+BUNDLE_MIRROR__HTTP://RUBYGEMS__ORG/: https://gems.stembolt.io/
+EOF
+
 exec gosu ci bash /run_test.sh "$@"


### PR DESCRIPTION
This should improve build times considerably as most of our builds end
up pulling down the exact same gems multiple times.
