### PR TITLE
Lock ubuntu version down

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:trusty
 
 ENV DEBIAN_FRONTEND noninteractive
 


### PR DESCRIPTION
Since a new ubuntu has been released since this Dockerfile was created,
and some stuff breaks on the newer release. Locking to trusty makes
things work and is safe for a few years yet.
