### PR TITLE
Add elasticsearch support.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,10 @@ RUN \
     curl -sS -L https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add - && \
     echo "deb http://packages.erlang-solutions.com/ubuntu $(lsb_release -sc) contrib" >> /etc/apt/sources.list && \
     curl -sS -L https://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc | apt-key add - && \
+    echo "deb http://ppa.launchpad.net/webupd8team/java/ubuntu $(lsb_release -sc) main" >> /etc/apt/sources.list && \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C2518248EEA14886 && \
     apt-get update && \
+    echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | debconf-set-selections && \
     apt-get install --no-install-recommends -y \
     build-essential \
     git-core \
@@ -44,7 +47,12 @@ RUN \
     parallel \
     libmagickcore-dev imagemagick libmagickwand-dev \
     qt5-default libqt5webkit5-dev \
- && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    oracle-java8-installer \
+ && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /var/cache/oracle-jdk8-installer
+
+RUN \
+    curl -Lo elasticsearch.deb https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.1.1.deb && \
+    dpkg -i elasticsearch.deb
 
 RUN yarn global add svgo karma-cli bower
 

--- a/init.sh
+++ b/init.sh
@@ -11,6 +11,12 @@ CI_UID=$(stat -c "%u" /workspace)
 useradd ci -u "$CI_UID" -d /cache
 chown ci:ci /cache
 
+if [ -n "$ELASTICSEARCH" ]; then
+    service elasticsearch start
+
+    export ELASTICSEARCH_URL="http://127.0.0.1:9200"
+fi
+
 if [ -n "$POSTGRESQL" ]; then
 	# Make PostgreSQL YOLOFAST
 	# Suggestions from http://stackoverflow.com/questions/9407442/optimise-postgresql-for-fast-testing


### PR DESCRIPTION
add-apt-repository requires other packages to be installed, so I wanted
to add the java prereq without it. I looked up the Key ID required for
it, and that's what I'm using here with apt-key. If there's a better
idea for this, please let me know.