### PR TITLE
Add ghostscript packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ RUN \
     xvfb \
     erlang \
     parallel \
+    ghostscript libgs-dev \
     libmagickcore-dev imagemagick libmagickwand-dev \
     qt5-default libqt5webkit5-dev \
     oracle-java8-installer \


### PR DESCRIPTION
The paperclip gem needs ghostscript for some operations on PDF files, like
converting to JPG.
I had a failing build after adding that feature, and this should fix that.