### PR TITLE
Set bundler config owner to ci user

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -84,5 +84,6 @@ cat > "$BUNDLE_APP_CONFIG/config" <<EOF
 BUNDLE_MIRROR__HTTPS://RUBYGEMS__ORG/: https://gems.stembolt.io/
 BUNDLE_MIRROR__HTTP://RUBYGEMS__ORG/: https://gems.stembolt.io/
 EOF
+chown ci:ci "$BUNDLE_APP_CONFIG/config"
 
 exec gosu ci bash /run_test.sh "$@"


### PR DESCRIPTION
For unknown reasons bundler attempts to use sudo if this file is not
writable by the user.